### PR TITLE
Implement Apps Script POST handler

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,42 @@
+// Replace with your destination spreadsheet information
+const SHEET_ID = 'REPLACE_WITH_SHEET_ID';
+const SHEET_NAME = 'Sheet1';
+
+function doGet(e) {
+  return HtmlService.createHtmlOutput('Apps Script is running');
+}
+
+function doPost(e) {
+  var data = {};
+  if (e.postData && e.postData.contents) {
+    data = JSON.parse(e.postData.contents);
+  }
+  var result = saveToSheet(data);
+  var output = ContentService.createTextOutput(JSON.stringify(result))
+    .setMimeType(ContentService.MimeType.JSON);
+  output.setHeader('Access-Control-Allow-Origin', '*');
+  output.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return output;
+}
+
+function doOptions() {
+  var output = ContentService.createTextOutput('')
+    .setMimeType(ContentService.MimeType.JSON);
+  output.setHeader('Access-Control-Allow-Origin', '*');
+  output.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return output;
+}
+
+function saveToSheet(data) {
+  // Use the provided spreadsheet ID or fall back to the active spreadsheet
+  var ss = (SHEET_ID === 'REPLACE_WITH_SHEET_ID')
+    ? SpreadsheetApp.getActiveSpreadsheet()
+    : SpreadsheetApp.openById(SHEET_ID);
+
+  var sheet = ss.getSheetByName(SHEET_NAME) || ss.getActiveSheet();
+  sheet.appendRow([new Date(), JSON.stringify(data)]);
+  return {status: 'success'};
+}
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # visbility
 Visibility Control Assessment
+
+## Google Apps Script Backend
+
+The `Code.gs` file provides `doGet`, `doPost`, and `doOptions` functions so
+responses can be written to a Google Sheet. Update `SHEET_ID` and `SHEET_NAME`
+at the top of `Code.gs` with your destination spreadsheet information. Deploy
+the script as a Web App and note the deployment URL for use by your frontend.

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,10 @@
+{
+  "timeZone": "Asia/Taipei",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  }
+}


### PR DESCRIPTION
## Summary
- add CORS-enabled Apps Script functions for POST requests
- use active spreadsheet if SHEET_ID is left as placeholder
- update manifest with webapp settings and Taiwan time zone
- document setup in README

## Testing
- `node -v`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686011cab7c08322b8564421f5c6f03e