### PR TITLE
Fix questionnaire visuals

### DIFF
--- a/questionnaire.css
+++ b/questionnaire.css
@@ -334,7 +334,7 @@ body {
         margin-bottom: 5px;
     }
     .qa-item .qa-a {
-        color: #28a745;
+        color: #000;
         font-weight: 500;
     }
     .overall-evaluation-item {
@@ -805,7 +805,7 @@ body {
     margin-bottom: 5px;
 }
 .qa-item .qa-a {
-    color: #28a745;
+    color: #000;
     font-weight: 500;
 }
 .overall-evaluation-item {

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -127,7 +127,7 @@
                                         <img src="blind.png" alt="Blind Spot Identification Icon" class="w-12 h-12">
                                     </div>
                                     <div>
-                                        <h3 class="text-xl font-bold text-orange-500">Blind Spot Identification 「來源可視性」</h3>
+                                        <h3 class="text-xl font-bold" style="color:#ff8000;">Blind Spot Identification 「來源可視性」</h3>
                                         <p class="text-gray-600 mt-2 leading-relaxed">此構面探討企業是否掌握了所有關鍵流量來源，包括南向北與東西向通訊、雲端與本地環境、已管理與未管理設備等。若缺乏正確的鏡像來源，將導致工具「看不到」，形同盲目作戰。</p>
                                     </div>
                                 </div>
@@ -136,7 +136,7 @@
                                        <img src="intelligence.png" alt="Intelligence Qualification Icon" class="w-12 h-12">
                                     </div>
                                     <div>
-                                        <h3 class="text-xl font-bold text-orange-500">Intelligence Qualification 「數據完整性」</h3>
+                                        <h3 class="text-xl font-bold" style="color:#ff8000;">Intelligence Qualification 「數據完整性」</h3>
                                         <p class="text-gray-600 mt-2 leading-relaxed">具備流量不代表具備洞察。此構面關注流量是否經過適當處理：是否去除重複、是否裁切、是否解密或轉換成 metadata，避免工具因雜訊過多而效能下降或告警誤判。</p>
                                     </div>
                                 </div>
@@ -145,7 +145,7 @@
                                        <img src="tool.png" alt="Tool Effectiveness Icon" class="w-12 h-12">
                                    </div>
                                    <div>
-                                        <h3 class="text-xl font-bold text-orange-500">Tool Effectiveness 「工具有效性」</h3>
+                                        <h3 class="text-xl font-bold" style="color:#ff8000;">Tool Effectiveness 「工具有效性」</h3>
                                         <p class="text-gray-600 mt-2 leading-relaxed">資訊是否有被送到對的工具，是評估能否轉化為資安價值的關鍵。此構面分析現有工具是否正確佈建、是否與業務量點流量相對應，並檢視部署是否過度、重疊或失效。</p>
                                     </div>
                                 </div>
@@ -197,7 +197,7 @@
                     <div class="absolute inset-0 bg-black bg-opacity-70"></div>
                     
                     <!-- 頁尾內容 -->
-                    <div class="relative max-w-screen-xl mx-auto p-6 md:p-10 lg:p-12 min-h-screen flex flex-col justify-center">
+                    <div class="relative max-w-screen-xl mx-auto p-6 md:p-10 lg:p-12 flex flex-col justify-center">
                     <div id="ending-section-content">
                     <!-- Dynamic content will be inserted here -->
                     <h2 class="text-2xl md:text-3xl font-bold mb-2">計畫行動</h2>
@@ -231,10 +231,10 @@
                                 <div class="space-y-3">
                                     <p class="font-bold">Learn More : https://www.gigamon.com/</p>
                                     <ul class="list-disc list-inside space-y-2 pl-4 text-gray-300">
-                                        <li><a href="#" class="hover:text-orange-400">Resource Library</a></li>
-                                        <li><a href="#" class="hover:text-orange-400">Learning Center</a></li>
-                                        <li><a href="#" class="hover:text-orange-400">Tech Hub Videos</a></li>
-                                        <li><a href="#" class="hover:text-orange-400">Webinars</a></li>
+                                        <li><a href="https://www.gigamon.com/search-results.html?&t=All&sort=relevancy#t=Resources" class="hover:text-orange-400">Resource Library</a></li>
+                                        <li><a href="https://www.gigamon.com/resources/learning-center.html" class="hover:text-orange-400">Learning Center</a></li>
+                                        <li><a href="https://www.gigamon.com/lp/tech-hub.html" class="hover:text-orange-400">Tech Hub Videos</a></li>
+                                        <li><a href="https://www.gigamon.com/resources/resource-library/webinar-hub.html" class="hover:text-orange-400">Webinars</a></li>
                                     </ul>
                                 </div>
                             </div>

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -250,10 +250,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const quizAreaEl = document.getElementById('quiz-area');
     const completionAreaEl = document.getElementById('completion-area');
     const userSummaryEl = document.getElementById('user-summary');
-    const moduleRecommendationsContainerEl = document.getElementById('module-recommendations-container');
-    const overallEvaluationContainerEl = document.getElementById('overall-evaluation-container');
-    const loadingEl = document.getElementById('loading');
-    const submitStatusEl = document.getElementById('submit-status');
+const moduleRecommendationsContainerEl = document.getElementById('module-recommendations-container');
+const overallEvaluationContainerEl = document.getElementById('overall-evaluation-container');
+const loadingEl = document.getElementById('loading');
+const submitStatusEl = document.getElementById('submit-status');
+
+    // Icons for module titles
+    const moduleIcons = {
+        "來源可視性 Blind Spot Identification": "blind.png",
+        "數據完整性 Intelligence Qualification": "intelligence.png",
+        "工具有效性 Tool Effectiveness": "tool.png"
+    };
 
     // --- FUNCTIONS ---
     function initQuiz() {
@@ -460,7 +467,10 @@ document.addEventListener('DOMContentLoaded', () => {
             qaHtml += '</div>';
 
             moduleBlock.innerHTML = `
-                <h4 class="module-title">${moduleName}</h4>
+                <div class="flex items-center gap-2 module-header">
+                    <img src="${moduleIcons[moduleName] || ''}" alt="${moduleName} Icon" class="w-8 h-8">
+                    <h4 class="module-title">${moduleName}</h4>
+                </div>
                 <div class="risk-level">Risk Level: ${riskLevelMap[riskLevel] || riskLevel}</div>
                 
                 <div class="findings-block">
@@ -586,7 +596,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     /**
-     * Exports the report section as a multi-page PDF file.
+     * 將報告區塊匯出為單一長頁面的 PDF 檔案。
+     * 移除 A4 分頁邏輯以避免內容被裁切。
      */
     function exportReportAsPDF() {
         const { jsPDF } = window.jspdf;
@@ -594,67 +605,42 @@ document.addEventListener('DOMContentLoaded', () => {
         const downloadButton = document.getElementById('download-pdf-btn');
         const originalButtonText = downloadButton.textContent;
 
-        // --- Prepare for capture ---
+        // --- 準備擷取畫面 ---
         downloadButton.textContent = '報告產生中...';
         downloadButton.disabled = true;
-        // Hide the button so it doesn't appear in the PDF
         downloadButton.style.visibility = 'hidden';
 
         html2canvas(reportElement, {
-            scale: 1, // lower scale to reduce file size
+            scale: 1.5, // 提高清晰度
             useCORS: true,
             logging: false,
             windowWidth: reportElement.scrollWidth,
             windowHeight: reportElement.scrollHeight
         }).then(canvas => {
+            const canvasWidth = canvas.width;
+            const canvasHeight = canvas.height;
+
+            const pdfWidth = 210; // A4 寬度約 210mm
+            const pdfHeight = (canvasHeight * pdfWidth) / canvasWidth;
+
             const pdf = new jsPDF({
                 orientation: 'p',
                 unit: 'mm',
-                format: 'a4'
+                format: [pdfWidth, pdfHeight]
             });
 
-            const pdfWidth = pdf.internal.pageSize.getWidth();
-            const pdfHeight = pdf.internal.pageSize.getHeight();
-
-            const pageHeightPx = canvas.width * (pdfHeight / pdfWidth);
-            let renderedHeight = 0;
-            const pageCanvas = document.createElement('canvas');
-            const pageCtx = pageCanvas.getContext('2d');
-
-            while (renderedHeight < canvas.height) {
-                const remaining = canvas.height - renderedHeight;
-                pageCanvas.width = canvas.width;
-                pageCanvas.height = Math.min(pageHeightPx, remaining);
-                pageCtx.clearRect(0, 0, pageCanvas.width, pageCanvas.height);
-                pageCtx.drawImage(
-                    canvas,
-                    0,
-                    renderedHeight,
-                    canvas.width,
-                    pageCanvas.height,
-                    0,
-                    0,
-                    canvas.width,
-                    pageCanvas.height
-                );
-
-                const imgData = pageCanvas.toDataURL('image/jpeg', 0.8);
-                if (renderedHeight > 0) pdf.addPage();
-                pdf.addImage(imgData, 'JPEG', 0, 0, pdfWidth, pdfHeight);
-
-                renderedHeight += pageHeightPx;
-            }
+            const imgData = canvas.toDataURL('image/jpeg', 0.85);
+            pdf.addImage(imgData, 'JPEG', 0, 0, pdfWidth, pdfHeight);
 
             pdf.save('可視化控管評估報告.pdf');
 
-            // --- Restore UI after capture ---
+            // --- 完成後恢復 UI ---
             downloadButton.textContent = originalButtonText;
             downloadButton.disabled = false;
             downloadButton.style.visibility = 'visible';
         }).catch(error => {
             console.error("PDF 產生錯誤:", error);
             alert("抱歉，產生 PDF 時發生錯誤。");
-            // Restore UI in case of an error
             downloadButton.textContent = originalButtonText;
             downloadButton.disabled = false;
             downloadButton.style.visibility = 'visible';


### PR DESCRIPTION
## Summary
- update heading styles to orange
- add icons to recommendation module headers
- change Q&A answer color to black
- update resource links for more info
- remove A4 page splitting in PDF export
- remove fixed footer height that caused blank pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864a40e82b08322a4e548b694c4595a