### PR TITLE
Fix questionnaire visuals

### DIFF
--- a/questionnaire.css
+++ b/questionnaire.css
@@ -289,10 +289,19 @@ body {
     .module-result-block .risk-level {
         font-size: 1em;
         font-weight: bold;
-        color: #ff8000;
+        color: #000;
         margin-bottom: 20px;
         padding-bottom: 10px;
         border-bottom: 1px solid #eee;
+    }
+    .module-result-block .risk-level .risk-value.low {
+        color: #28a745;
+    }
+    .module-result-block .risk-level .risk-value.medium {
+        color: #ff8000;
+    }
+    .module-result-block .risk-level .risk-value.high {
+        color: #dc3545;
     }
     .findings-block, .recommendations-block, .qa-block {
         margin-bottom: 20px;
@@ -334,7 +343,7 @@ body {
         margin-bottom: 5px;
     }
     .qa-item .qa-a {
-        color: #28a745;
+        color: #000;
         font-weight: 500;
     }
     .overall-evaluation-item {
@@ -757,14 +766,6 @@ body {
     margin-top: 0;
     margin-bottom: 5px;
 }
-.module-result-block .risk-level {
-    font-size: 1em;
-    font-weight: bold;
-    color: #ff8000;
-    margin-bottom: 20px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #eee;
-}
 .findings-block, .recommendations-block, .qa-block {
     margin-bottom: 20px;
 }
@@ -805,7 +806,7 @@ body {
     margin-bottom: 5px;
 }
 .qa-item .qa-a {
-    color: #28a745;
+    color: #000;
     font-weight: 500;
 }
 .overall-evaluation-item {

--- a/questionnaire.css
+++ b/questionnaire.css
@@ -306,6 +306,12 @@ body {
     .findings-block, .recommendations-block, .qa-block {
         margin-bottom: 20px;
     }
+    .findings-block, .recommendations-block {
+        background-color: #f8f9fa;
+        padding: 15px;
+        border-radius: 5px;
+        border: 1px solid #e9ecef;
+    }
     .findings-block h5, .recommendations-block h5, .qa-block h5 {
         font-size: 1.2em;
         color: #343a40;
@@ -323,10 +329,10 @@ body {
         margin-top: 10px;
     }
     .qa-item {
-        background-color: #f8f9fa;
-        padding: 15px;
-        border-radius: 5px;
-        border: 1px solid #e9ecef;
+        background-color: transparent;
+        padding: 0;
+        border-radius: 0;
+        border: none;
     }
     .qa-item .qa-header {
         font-weight: bold;
@@ -769,6 +775,12 @@ body {
 .findings-block, .recommendations-block, .qa-block {
     margin-bottom: 20px;
 }
+.findings-block, .recommendations-block {
+    background-color: #f8f9fa;
+    padding: 15px;
+    border-radius: 5px;
+    border: 1px solid #e9ecef;
+}
 .findings-block h5, .recommendations-block h5, .qa-block h5 {
     font-size: 1.2em;
     color: #343a40;
@@ -786,10 +798,10 @@ body {
     margin-top: 10px;
 }
 .qa-item {
-    background-color: #f8f9fa;
-    padding: 15px;
-    border-radius: 5px;
-    border: 1px solid #e9ecef;
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+    border: none;
 }
 .qa-item .qa-header {
     font-weight: bold;

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -71,7 +71,7 @@
                         
                         <!-- 第二區塊：重視「可視性」這件事 -->
                         <section class="mb-12">
-                            <h2 class="text-2xl md:text-3xl font-bold text-center text-gray-800">重視「可視性」這件事</h2>
+                            <h2 class="text-center font-bold text-gray-800" style="font-size:12pt;">重視「可視性」這件事</h2>
                             <div class="section-divider"></div>
                             <p class="text-center text-gray-600 max-w-3xl mx-auto leading-relaxed mb-12" style="font-size:10pt;line-height:14pt;font-family:'Century Gothic','Microsoft JhengHei','微軟正黑體',sans-serif;">
                                 在數位轉型與混合雲快速擴張的今天，企業面對的資安挑戰已不再只是防火牆邊界，而是分散在不同環境中的不可見風險。可視性已成為資安成敗的關鍵基礎，而非附屬條件。唯有在看得清楚的前提下，防護、回應、合規、轉型與最佳化才具備實踐的可能。<br>
@@ -82,32 +82,32 @@
                                 <!-- Icon 1: Cyberthreat Detection -->
                                 <div class="flex flex-col items-center p-4 bg-gray-100 rounded-lg">
                                     <img src="cyber.png" alt="Cyberthreat Protection Icon" class="w-16 h-16 mb-2">
-                                    <h3 class="font-bold text-black mb-2 text-base">Cyberthreat Protection</h3>
-                                    <p class="text-sm text-black">有效防禦來自 OT、IoT 與未受管控設備的風險，掌握 lateral movement（橫向移動）與 ransomware C2（勒索軟體的指揮控制）行為，企業必須先看得到這些流量。沒有可視性，就沒有主動防禦的能力。</p>
+                                    <h3 class="font-bold text-black mb-2" style="font-size:10pt;">Cyberthreat Protection</h3>
+                                    <p class="text-black" style="font-size:8pt;">有效防禦來自 OT、IoT 與未受管控設備的風險，掌握 lateral movement（橫向移動）與 ransomware C2（勒索軟體的指揮控制）行為，企業必須先看得到這些流量。沒有可視性，就沒有主動防禦的能力。</p>
                                 </div>
                                 <!-- Icon 2: Response & Recovery -->
                                 <div class="flex flex-col items-center p-4 bg-gray-100 rounded-lg">
                                     <img src="response.png" alt="Response & Recovery Icon" class="w-16 h-16 mb-2">
-                                    <h3 class="font-bold text-black mb-2 text-base">Response Recovery</h3>
-                                    <p class="text-sm text-black">可視性是提升 MTTR（平均修復時間）、降低 dwell time（攻擊停留時間）與強化 intrusion investigation（入侵調查）品質的基礎。缺乏高品質的流量資料，回應與復原將淪為盲目猜測。</p>
+                                    <h3 class="font-bold text-black mb-2" style="font-size:10pt;">Response &amp; Recovery</h3>
+                                    <p class="text-black" style="font-size:8pt;">可視性是提升 MTTR（平均修復時間）、降低 dwell time（攻擊停留時間）與強化 intrusion investigation（入侵調查）品質的基礎。缺乏高品質的流量資料，回應與復原將淪為盲目猜測。</p>
                                 </div>
                                 <!-- Icon 3: Standards & Compliance -->
                                 <div class="flex flex-col items-center p-4 bg-gray-100 rounded-lg">
                                     <img src="standard.png" alt="Standards & Compliance Icon" class="w-16 h-16 mb-2">
-                                    <h3 class="font-bold text-black mb-2 text-base">Standards Compliance</h3>
-                                    <p class="text-sm text-black">面對如 PCI、Zero Trust、M-21-31、MITRE、OWASP 等標準的要求，企業必須能證明自身具備橫向通訊、加密流量與未受管控節點的可視性，否則難以達成合規與稽核驗證。</p>
+                                    <h3 class="font-bold text-black mb-2" style="font-size:10pt;">Standards Compliance</h3>
+                                    <p class="text-black" style="font-size:8pt;">面對如 PCI、Zero Trust、M-21-31、MITRE、OWASP 等標準的要求，企業必須能證明自身具備橫向通訊、加密流量與未受管控節點的可視性，否則難以達成合規與稽核驗證。</p>
                                 </div>
                                 <!-- Icon 4: Business Modernization -->
                                 <div class="flex flex-col items-center p-4 bg-gray-100 rounded-lg">
                                     <img src="business.png" alt="Business Modernization Icon" class="w-16 h-16 mb-2">
-                                    <h3 class="font-bold text-black mb-2 text-base">Business Modernization</h3>
-                                    <p class="text-sm text-black">在推動 cloud migration（雲端遷移）、DevOps initiatives（開發與營運整合）與 NetFlow offload（流量卸載）過程中，若缺乏可視性，資安將成為阻礙現代化的障礙，而非推進力量。</p>
+                                    <h3 class="font-bold text-black mb-2" style="font-size:10pt;">Business Modernization</h3>
+                                    <p class="text-black" style="font-size:8pt;">在推動 cloud migration（雲端遷移）、DevOps initiatives（開發與營運整合）與 NetFlow offload（流量卸載）過程中，若缺乏可視性，資安將成為阻礙現代化的障礙，而非推進力量。</p>
                                 </div>
                                 <!-- Icon 5: Cost Optimization -->
                                 <div class="flex flex-col items-center p-4 bg-gray-100 rounded-lg">
                                     <img src="cost.png" alt="Cost Optimization Icon" class="w-16 h-16 mb-2">
-                                    <h3 class="font-bold text-black mb-2 text-base">Cost <br>Optimization</h3>
-                                    <p class="text-sm text-black">可視性讓工具能專注處理關鍵流量，避免過載與誤報，達成 tool optimization（工具效能優化）、noise reduction（雜訊減少）與 cloud NDR savings（降低雲端 NDR 成本）等效益。</p>
+                                    <h3 class="font-bold text-black mb-2" style="font-size:10pt;">Cost Optimization</h3>
+                                    <p class="text-black" style="font-size:8pt;">可視性讓工具能專注處理關鍵流量，避免過載與誤報，達成 tool optimization（工具效能優化）、noise reduction（雜訊減少）與 cloud NDR savings（降低雲端 NDR 成本）等效益。</p>
                                 </div>
                             </div>
                         </section>
@@ -115,9 +115,9 @@
                         <p class="text-center italic underline my-12" style="font-size:10pt;line-height:14pt;font-family:'Century Gothic','Microsoft JhengHei','微軟正黑體',sans-serif;">可視性不是結果，而是達成以上所有安全目標的前提。</p>
 
                         <section>
-                            <h2 class="text-2xl md:text-3xl font-bold text-center text-gray-800">三大構面 檢視可視性管理落差</h2>
+                            <h2 class="text-center font-bold text-gray-800" style="font-size:12pt;">三大構面 檢視可視性管理落差</h2>
                             <div class="section-divider"></div>
-                            <p class="text-center text-gray-600 max-w-3xl mx-auto leading-relaxed mb-12">
+                            <p class="text-center text-gray-600 max-w-3xl mx-auto leading-relaxed mb-12" style="font-size:10pt;">
                                 本評估將以此為核心，協助企業盤點現況、發現落差，並為強化安全治理與資安投資效益打下基礎。
                             </p>
 
@@ -127,7 +127,7 @@
                                         <img src="blind.png" alt="Blind Spot Identification Icon" class="w-12 h-12">
                                     </div>
                                     <div>
-                                        <h3 class="text-xl font-bold text-orange-500">Blind Spot Identification 「來源可視性」</h3>
+                                        <h3 class="text-xl font-bold" style="color:#ff8000;">Blind Spot Identification 「來源可視性」</h3>
                                         <p class="text-gray-600 mt-2 leading-relaxed">此構面探討企業是否掌握了所有關鍵流量來源，包括南向北與東西向通訊、雲端與本地環境、已管理與未管理設備等。若缺乏正確的鏡像來源，將導致工具「看不到」，形同盲目作戰。</p>
                                     </div>
                                 </div>
@@ -136,7 +136,7 @@
                                        <img src="intelligence.png" alt="Intelligence Qualification Icon" class="w-12 h-12">
                                     </div>
                                     <div>
-                                        <h3 class="text-xl font-bold text-orange-500">Intelligence Qualification 「數據完整性」</h3>
+                                        <h3 class="text-xl font-bold" style="color:#ff8000;">Intelligence Qualification 「數據完整性」</h3>
                                         <p class="text-gray-600 mt-2 leading-relaxed">具備流量不代表具備洞察。此構面關注流量是否經過適當處理：是否去除重複、是否裁切、是否解密或轉換成 metadata，避免工具因雜訊過多而效能下降或告警誤判。</p>
                                     </div>
                                 </div>
@@ -145,7 +145,7 @@
                                        <img src="tool.png" alt="Tool Effectiveness Icon" class="w-12 h-12">
                                    </div>
                                    <div>
-                                        <h3 class="text-xl font-bold text-orange-500">Tool Effectiveness 「工具有效性」</h3>
+                                        <h3 class="text-xl font-bold" style="color:#ff8000;">Tool Effectiveness 「工具有效性」</h3>
                                         <p class="text-gray-600 mt-2 leading-relaxed">資訊是否有被送到對的工具，是評估能否轉化為資安價值的關鍵。此構面分析現有工具是否正確佈建、是否與業務量點流量相對應，並檢視部署是否過度、重疊或失效。</p>
                                     </div>
                                 </div>
@@ -160,8 +160,8 @@
                     <hr>
                     <div id="user-summary"></div>
                     <h3 class="centered-h3">
-                        <span style="font-size:12pt;font-weight:bold;color:#000;">關鍵發現</span><br>
-                        <span style="font-size:10pt;color:#000;">Key Findings & Recommendations</span>
+                        <span style="font-size:12pt;font-weight:bold;color:#000;">關鍵發現與建議</span><br>
+                        <span style="font-size:10pt;color:#000;">Key Findings &amp; Recommendations</span>
                     </h3>
                     <div id="overall-summary-block" class="my-8 w-full">
                         <div class="summary-left">
@@ -197,7 +197,7 @@
                     <div class="absolute inset-0 bg-black bg-opacity-70"></div>
                     
                     <!-- 頁尾內容 -->
-                    <div class="relative max-w-screen-xl mx-auto p-6 md:p-10 lg:p-12 min-h-screen flex flex-col justify-center">
+                    <div class="relative max-w-screen-xl mx-auto p-6 md:p-10 lg:p-12 flex flex-col justify-center">
                     <div id="ending-section-content">
                     <!-- Dynamic content will be inserted here -->
                     <h2 class="text-2xl md:text-3xl font-bold mb-2">計畫行動</h2>
@@ -231,10 +231,10 @@
                                 <div class="space-y-3">
                                     <p class="font-bold">Learn More : https://www.gigamon.com/</p>
                                     <ul class="list-disc list-inside space-y-2 pl-4 text-gray-300">
-                                        <li><a href="#" class="hover:text-orange-400">Resource Library</a></li>
-                                        <li><a href="#" class="hover:text-orange-400">Learning Center</a></li>
-                                        <li><a href="#" class="hover:text-orange-400">Tech Hub Videos</a></li>
-                                        <li><a href="#" class="hover:text-orange-400">Webinars</a></li>
+                                        <li><a href="https://www.gigamon.com/search-results.html?&t=All&sort=relevancy#t=Resources" class="hover:text-orange-400">Resource Library</a></li>
+                                        <li><a href="https://www.gigamon.com/resources/learning-center.html" class="hover:text-orange-400">Learning Center</a></li>
+                                        <li><a href="https://www.gigamon.com/lp/tech-hub.html" class="hover:text-orange-400">Tech Hub Videos</a></li>
+                                        <li><a href="https://www.gigamon.com/resources/resource-library/webinar-hub.html" class="hover:text-orange-400">Webinars</a></li>
                                     </ul>
                                 </div>
                             </div>

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -483,7 +483,7 @@ const submitStatusEl = document.getElementById('submit-status');
                 </div>
 
                 <div class="qa-block">
-                    <h5>問答詳情 (Q&A Details)</h5>
+                    <h5>問答詳情</h5>
                     ${qaHtml}
                 </div>
             `;

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -250,10 +250,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const quizAreaEl = document.getElementById('quiz-area');
     const completionAreaEl = document.getElementById('completion-area');
     const userSummaryEl = document.getElementById('user-summary');
-    const moduleRecommendationsContainerEl = document.getElementById('module-recommendations-container');
-    const overallEvaluationContainerEl = document.getElementById('overall-evaluation-container');
-    const loadingEl = document.getElementById('loading');
-    const submitStatusEl = document.getElementById('submit-status');
+const moduleRecommendationsContainerEl = document.getElementById('module-recommendations-container');
+const overallEvaluationContainerEl = document.getElementById('overall-evaluation-container');
+const loadingEl = document.getElementById('loading');
+const submitStatusEl = document.getElementById('submit-status');
+
+    // Icons for module titles
+    const moduleIcons = {
+        "來源可視性 Blind Spot Identification": "blind.png",
+        "數據完整性 Intelligence Qualification": "intelligence.png",
+        "工具有效性 Tool Effectiveness": "tool.png"
+    };
 
     // --- FUNCTIONS ---
     function initQuiz() {
@@ -460,8 +467,11 @@ document.addEventListener('DOMContentLoaded', () => {
             qaHtml += '</div>';
 
             moduleBlock.innerHTML = `
-                <h4 class="module-title">${moduleName}</h4>
-                <div class="risk-level">Risk Level: ${riskLevelMap[riskLevel] || riskLevel}</div>
+                <div class="flex items-center gap-2 module-header">
+                    <img src="${moduleIcons[moduleName] || ''}" alt="${moduleName} Icon" class="w-8 h-8">
+                    <h4 class="module-title">${moduleName}</h4>
+                </div>
+                <div class="risk-level">Risk Level: <span class="risk-value ${ (riskLevelMap[riskLevel] || riskLevel).toLowerCase() }">${riskLevelMap[riskLevel] || riskLevel}</span></div>
                 
                 <div class="findings-block">
                     <p>${recommendationContent.finding}</p>
@@ -586,7 +596,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     /**
-     * Exports the report section as a multi-page PDF file.
+     * 將報告區塊匯出為單一長頁面的 PDF 檔案。
+     * 移除 A4 分頁邏輯以避免內容被裁切。
      */
     function exportReportAsPDF() {
         const { jsPDF } = window.jspdf;
@@ -594,67 +605,42 @@ document.addEventListener('DOMContentLoaded', () => {
         const downloadButton = document.getElementById('download-pdf-btn');
         const originalButtonText = downloadButton.textContent;
 
-        // --- Prepare for capture ---
+        // --- 準備擷取畫面 ---
         downloadButton.textContent = '報告產生中...';
         downloadButton.disabled = true;
-        // Hide the button so it doesn't appear in the PDF
         downloadButton.style.visibility = 'hidden';
 
         html2canvas(reportElement, {
-            scale: 1, // lower scale to reduce file size
+            scale: 1.5, // 提高清晰度
             useCORS: true,
             logging: false,
             windowWidth: reportElement.scrollWidth,
             windowHeight: reportElement.scrollHeight
         }).then(canvas => {
+            const canvasWidth = canvas.width;
+            const canvasHeight = canvas.height;
+
+            const pdfWidth = 210; // A4 寬度約 210mm
+            const pdfHeight = (canvasHeight * pdfWidth) / canvasWidth;
+
             const pdf = new jsPDF({
                 orientation: 'p',
                 unit: 'mm',
-                format: 'a4'
+                format: [pdfWidth, pdfHeight]
             });
 
-            const pdfWidth = pdf.internal.pageSize.getWidth();
-            const pdfHeight = pdf.internal.pageSize.getHeight();
-
-            const pageHeightPx = canvas.width * (pdfHeight / pdfWidth);
-            let renderedHeight = 0;
-            const pageCanvas = document.createElement('canvas');
-            const pageCtx = pageCanvas.getContext('2d');
-
-            while (renderedHeight < canvas.height) {
-                const remaining = canvas.height - renderedHeight;
-                pageCanvas.width = canvas.width;
-                pageCanvas.height = Math.min(pageHeightPx, remaining);
-                pageCtx.clearRect(0, 0, pageCanvas.width, pageCanvas.height);
-                pageCtx.drawImage(
-                    canvas,
-                    0,
-                    renderedHeight,
-                    canvas.width,
-                    pageCanvas.height,
-                    0,
-                    0,
-                    canvas.width,
-                    pageCanvas.height
-                );
-
-                const imgData = pageCanvas.toDataURL('image/jpeg', 0.8);
-                if (renderedHeight > 0) pdf.addPage();
-                pdf.addImage(imgData, 'JPEG', 0, 0, pdfWidth, pdfHeight);
-
-                renderedHeight += pageHeightPx;
-            }
+            const imgData = canvas.toDataURL('image/jpeg', 0.85);
+            pdf.addImage(imgData, 'JPEG', 0, 0, pdfWidth, pdfHeight);
 
             pdf.save('可視化控管評估報告.pdf');
 
-            // --- Restore UI after capture ---
+            // --- 完成後恢復 UI ---
             downloadButton.textContent = originalButtonText;
             downloadButton.disabled = false;
             downloadButton.style.visibility = 'visible';
         }).catch(error => {
             console.error("PDF 產生錯誤:", error);
             alert("抱歉，產生 PDF 時發生錯誤。");
-            // Restore UI in case of an error
             downloadButton.textContent = originalButtonText;
             downloadButton.disabled = false;
             downloadButton.style.visibility = 'visible';


### PR DESCRIPTION
## Summary
- update heading styles to orange
- add icons to recommendation module headers
- change Q&A answer color to black
- update resource links for more info
- remove A4 page splitting in PDF export
- remove fixed footer height that caused blank pages
- tweak heading font sizes and risk level colors
- remove manual break for Cost Optimization heading

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864a40e82b08322a4e548b694c4595a