### PR TITLE
Fix: Update report section background color for better visibility

### DIFF
--- a/report.css
+++ b/report.css
@@ -251,7 +251,7 @@
     /* Styles for Key Findings and Recommendations sections */
     #key-findings-container,
     #recommendations-container {
-        background-color: #f8f9fa;
+    background-color: #e9ecef; /* Changed to a more visible gray */
         padding: 20px;
         margin-top: 15px;
         border-radius: 5px;


### PR DESCRIPTION
The background color for the 'Key Findings & Recommendations' sections in the report was too light (#f8f9fa), making it appear almost white. This commit changes the background color to #e9ecef, a more distinct gray, to ensure the black text is clearly visible against a noticeable gray background.

Also reviewed questionnaire.html and questionnaire.css for any obvious issues as part of the task.